### PR TITLE
documented :index, added a :with option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -130,6 +130,17 @@ If you want to pass some options for rails' +add_index()+ you can use hash param
     t.string :userid, :index => { :unique => true }
   end
 
+You can also define a multi-column index by specifying a +:with+ option
+listing one or more additional columns to be passed to +add_index()+.
+
+  create_table :users do |t|
+    t.integer :group_id
+    t.integer :member_number, :index => { :with => :group_id, :unique => true }
+    t.integer :country_code
+    t.string  :area_code
+    t.string  :local_phone,   :index => { :with => [:country_code, :area_code], :unique => true }
+  end
+
 === Configuration
 
 For customization purposes create config/initializers/automatic_foreign_key.rb file:

--- a/README.rdoc
+++ b/README.rdoc
@@ -4,6 +4,9 @@ Automatic Foreign Key is an ActiveRecord extension that automatically generates 
 constraints when creating tables. It uses SQL-92 syntax and as such should be
 compatible with most databases that support foreign-key constraints.
 
+As a bonus, the extension also allows you to create indices on columns via
+options to the schema column definition statements.
+
 === Installation
 
 As a gem
@@ -110,6 +113,22 @@ If you want to pass some options for index use hash params.
 
 Auto indexing option is useless for MySQL users as their RDBMS adds indices on foreign
 keys by default. However PostgreSQL users may have fun with that feature.
+
+=== Column Indices 
+
+You can create an index on any column by specifying the +:index+ option.
+
+  create_table :users do |t|
+    ...
+    t.string :role, :index => true
+  end
+
+If you want to pass some options for rails' +add_index()+ you can use hash params.
+
+  create_table :users do |t|
+    ...
+    t.string :userid, :index => { :unique => true }
+  end
 
 === Configuration
 

--- a/lib/automatic_foreign_key/active_record/connection_adapters/schema_statements.rb
+++ b/lib/automatic_foreign_key/active_record/connection_adapters/schema_statements.rb
@@ -14,7 +14,8 @@ module AutomaticForeignKey::ActiveRecord::ConnectionAdapters
         indices = table_definition.indices
       end
       indices.each do |column_name, index_options|
-        add_index(table, column_name, index_options)
+        column_names = [column_name] + Array.wrap(index_options.delete(:with))
+        add_index(table, column_names, index_options)
       end 
     end
 

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -47,6 +47,12 @@ describe ActiveRecord::Migration do
       create_table(@model, :state => { :index => true }) 
       @model.should have_index.on(:state)
     end
+
+    it "should create a multiple-column index if specified" do
+      create_table(@model, :city => {},
+                   :state => { :index => {:with => :city} } ) 
+      @model.should have_index.on([:state, :city])
+    end
     
     it "should auto-index foreign keys only" do
       AutomaticForeignKey.auto_index = true


### PR DESCRIPTION
hi.  thanks for maintaining the redhillonrails plugins and getting them working with rails 3 -- i've been using them for several years (even contirubted the occasional bug fix & feature to the original author) and was intending to dive into getting them working with rails 3 and putting them on github, when i found that you already did :)

anyway, as you'll see from the commits, i've updated the README to point out that this supports :index (i found out the hard way in that i had a separate plugin doing that, which lead to 'duplicate index' errors).  i also added an option to support multiple-column indexes, a feature that i rely on from that other plugin.  i hope you find the changes worthwhile.

best,
-ronen
