### PR TITLE
Configuration to disable FKs auto creation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -149,6 +149,8 @@ For customization purposes create config/initializers/automatic_foreign_key.rb f
     config.auto_index = true # create indices on FKs by default
     config.on_update = :cascade # cascade as default on_update action
     config.on_delete = :restrict # restrict as default on_delete action
+	config.auto_fk = false # create FKs for every column ending with _id.
+	config.auto_self_referential_fk = false # create a self reference to the table for parent_id column.
   end
 
 === Rails 3 compatibility

--- a/lib/automatic_foreign_key.rb
+++ b/lib/automatic_foreign_key.rb
@@ -29,6 +29,14 @@ module AutomaticForeignKey
   mattr_accessor :auto_index
   @@auto_index = nil
 
+  # Create a FK for every column with a name ending in _id (default true)
+  mattr_accessor :auto_fk
+  @@auto_fk = true
+
+  # Create a self reference to the table if a column is named parent_id
+  mattr_accessor :auto_self_referential_fk
+  @@auto_self_referential_fk = true
+
   def self.setup(&block)
     yield self
   end

--- a/lib/automatic_foreign_key/active_record/base.rb
+++ b/lib/automatic_foreign_key/active_record/base.rb
@@ -25,12 +25,12 @@ module AutomaticForeignKey::ActiveRecord
           references = options[:references]
           references = [references, :id] unless references.nil? || references.is_a?(Array)
           references
-        elsif column_name == 'parent_id'
-          [table_name, :id]
-        elsif column_name =~ /^(.*)_id$/
-          determined_table_name = ActiveRecord::Base.pluralize_table_names ? $1.to_s.pluralize : $1
-          [determined_table_name, :id]
-        end
+	    elsif AutomaticForeignKey.auto_self_referential_fk and column_name == 'parent_id'
+			  [table_name, :id]
+		elsif AutomaticForeignKey.auto_fk and column_name =~ /^(.*)_id$/
+			  determined_table_name = ActiveRecord::Base.pluralize_table_names ? $1.to_s.pluralize : $1
+			  [determined_table_name, :id]
+		end
       end
     end
   end

--- a/lib/generators/automatic_foreign_key/templates/automatic_foreign_key.rb
+++ b/lib/generators/automatic_foreign_key/templates/automatic_foreign_key.rb
@@ -12,5 +12,11 @@ AutomaticForeignKey.setup do |config|
   # It's relevant for PostgreSQL only.
   # MySQL engines auto-index foreign keys by default
   # config.auto_index = true
+  #
+  # Auto create foreign keys for every column with a name ending in _id.
+  # config.auto_fk = true
+  #
+  # Auto create a self reference to the table if a column is named parent_id.
+  # config.auto_self_referential_fk = true
 
 end


### PR DESCRIPTION
I am unable to use the whole plugin if it automatically add FKs for every column ending with _id.

Eg 1. Is impossible to use the plugin userstamp that use `t.userstamps` within a migration to add `creator_id` and  `updater_id` fields

Eg 2. If development DB dont support FKs (MySQL not InnoDB) but production DB support FKs I must disable the plugin because migrations fails.

So I add two configuration options to disable auto creation.

Unfortunately I have not made a topic branch and I am unable to fix indentation that is slightly different from yours.

Thanks for your plugin.

Best regards,
Antonio
